### PR TITLE
Warn users when adding duplicate site entries | Closes issue #31

### DIFF
--- a/manager.py
+++ b/manager.py
@@ -31,6 +31,9 @@ class PasswordManager:
                 self.password_dict[site] = Fernet(self.key).decrypt(encrypted.encode()).decode()
 
     def add_password(self, site, password):
+        if site in self.password_dict:  
+            print(f"Warning: A password for the site '{site}' already exists.")  
+            return 
         self.password_dict[site] = password
         if self.password_file is not None:
             with open(self.password_file, 'a+') as f:


### PR DESCRIPTION
**Related Issue**
Closes #31

**Type of Change**
- [x] New Feature

**Description of Change**
Adds a warning system to notify users when attempting to add a duplicate site entry in the password manager.

**Implementation Details**
- Added a duplicate check in the add_password method to verify if a site already exists in password_dict.
-  If a duplicate is found, a warning is displayed, and the password is not updated, preventing unintended overwrites.

Demo
![image](https://github.com/user-attachments/assets/8c37ff1e-350b-439d-84ca-28f25ed6b481)