### PR TITLE
Password Usage Categories for better Organization | Closes Issue #37

### DIFF
--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ def main():
           4. Load an existing password file
           5. Add a password
           6. Get a password
+          7. List all passwords by category
           q. Quit
           """)
     
@@ -38,10 +39,13 @@ def main():
         elif choice == '5':
             site = input("Enter site: ").strip()
             password = input("Enter password: ").strip()
-            pm.add_password(site, password)
+            category = input("Enter category (e.g., social, work, personal): ").strip()
+            pm.add_password(site, password,category)
         elif choice == '6':
             site = input("Enter site: ").strip()
-            print(f"Password for {site}: {pm.get_password(site)}")
+            print(pm.get_password(site))
+        elif choice == '7':
+            pm.list_passwords_by_category()
         elif choice == 'q':
             done = True
             print("Goodbye!")

--- a/manager.py
+++ b/manager.py
@@ -20,22 +20,38 @@ class PasswordManager:
     def create_password_file(self, path, initial_values=None):
         self.password_file = path
         if initial_values is not None:
-            for site, password in initial_values.items():
-                self.add_password(site, password)
+            for site, data in initial_values.items():
+                self.add_password(site, data["password"], data.get("category"))
 
     def load_password_file(self, path):
         self.password_file = path
         with open(path, 'r') as f:
             for line in f:
-                site, encrypted = line.split(":")
-                self.password_dict[site] = Fernet(self.key).decrypt(encrypted.encode()).decode()
+                site, encrypted, category = line.strip().split(":")
+                password = Fernet(self.key).decrypt(encrypted.encode()).decode()
+                self.password_dict[site] = {"password": password, "category": category}
 
-    def add_password(self, site, password):
-        self.password_dict[site] = password
+    def add_password(self, site, password, category="uncategorized"):
+        self.password_dict[site] = {"password": password, "category": category}
         if self.password_file is not None:
             with open(self.password_file, 'a+') as f:
                 encrypted = Fernet(self.key).encrypt(password.encode()).decode()
                 f.write(f"{site}:{encrypted}\n")
 
     def get_password(self, site):
-        return self.password_dict.get(site, "Password not found.")
+        data = self.password_dict.get(site)
+        if data:
+            return f"Password: {data['password']}, Category: {data['category']}"
+        return "Password not found."
+
+    def list_passwords_by_category(self):
+        selected_category = input("Enter the category you want to view: ").strip()
+        found = False
+        for site, data in self.password_dict.items():
+            if data["category"] == selected_category:
+                if not found:
+                    print(f"\nCategory: {selected_category}")
+                    found = True
+                print(f"{site}: {data['password']}")
+        if not found:
+            print(f"No passwords found for category: {selected_category}")


### PR DESCRIPTION
**Related Issue**
Closes #37 

**Type of Change**
- [x] New Feature
- [x]  Documentation Update

**Description of Change**

- Created a method to ask for categories of passwords being added.
- Output for 6 now displays the category when password is retrieved.
- Added extra feature no. 7, which lists ALL passwords in a specific category.
- 

**Implementation Details**

- Code accepts new parameter, of `category`.When a new password is added, both the password and its associated category are stored in `self.password_dict`
- edited `get_password` and added the method `Password: [password], Category: [category].`  which will help include both password and category in feature 6.
- option 7 calls the` list_passwords_by_category` which lists passwords by their category, by prompting the user and displaying matches.

**Demo**
![image](https://github.com/user-attachments/assets/79b5d0be-f9b2-49f3-a5d5-439641cbbe2f)
